### PR TITLE
Proposition de correction Méthode PwdFort

### DIFF
--- a/Habilitations/controller/FrmHabilitationsController.cs
+++ b/Habilitations/controller/FrmHabilitationsController.cs
@@ -109,15 +109,15 @@ namespace Habilitations.controller
         /// <returns></returns>
         public bool PwdFort(string pwd)
         {
-            if (pwd.Length < 8 && pwd.Length > 30)
-                return false;
-            if (!Regex.Match(pwd, @"[a-z]").Success)
-                return false;
-            if (!Regex.Match(pwd, @"[A-Z]").Success)
+            if (pwd.Length < 8 || pwd.Length > 30)
                 return false;
             if (!Regex.Match(pwd, @"[0-9]").Success)
+            return false;
+            if (!Regex.Match(pwd, @"\p{Ll}").Success)
                 return false;
-            if (!Regex.Match(pwd, @"\W").Success)
+            if (!Regex.Match(pwd, @"\p{Lu}").Success)
+                return false;
+            if (!Regex.Match(pwd, @"\p{P}").Success)
                 return false;
             if (Regex.Match(pwd, @"\s").Success)
                 return false;


### PR DESCRIPTION
Problème n°1 : pour que le "if" soit vrai, il fallait que le mot fasse moins de 8 caractères et plus de 30 caractères, en même temps (&&), ce qui n'est pas possible.

Solution : remplacer && par ||

Problème n°2 : l'expression régulier /W correspond à tout caractère qui ne fait pas partie de A-Z, a-z, 0-9 et _ . On voit bien que l'underscore fait partie de ces caractères, il est donc normal qu'il ne soit pas considéré comme caractère spécial

Solution : remplacer l'expression régulière \W par \p{p} , qui fait référence à tous les caractères de ponctuation, _ compris

Problème n°3 : les caractères minuscules accentuées ne sont pas considérés comme des caractères minuscules.

Solution : remplacement de [a-z] par \p{Ll} pour cibler toutes les minuscules et remplacement de [A-Z] par \p{Lu} pour cibler toutes les majuscules

Damien Verger