### PR TITLE
Problèmes sur le pwd corrigés.

### DIFF
--- a/Habilitations/controller/FrmHabilitationsController.cs
+++ b/Habilitations/controller/FrmHabilitationsController.cs
@@ -109,15 +109,15 @@ namespace Habilitations.controller
         /// <returns></returns>
         public bool PwdFort(string pwd)
         {
-            if (pwd.Length < 8 && pwd.Length > 30)
+            if (pwd.Length < 8 || pwd.Length > 30)
                 return false;
-            if (!Regex.Match(pwd, @"[a-z]").Success)
+            if (!Regex.Match(pwd, @"[a-z]").Success && !Regex.Match(pwd, @"[à-ž]").Success)
                 return false;
-            if (!Regex.Match(pwd, @"[A-Z]").Success)
+            if (!Regex.Match(pwd, @"[A-Z]").Success && !Regex.Match(pwd, @"[À-Ž]").Success)
                 return false;
             if (!Regex.Match(pwd, @"[0-9]").Success)
                 return false;
-            if (!Regex.Match(pwd, @"\W").Success)
+            if (!Regex.Match(pwd, @"\W").Success && !Regex.Match(pwd, @"_").Success)
                 return false;
             if (Regex.Match(pwd, @"\s").Success)
                 return false;


### PR DESCRIPTION
Problème n°1 : il fallait mettre un OU au lieu du ET dans la première condition.
Problème n°2 : j'ai ajouté, au 4° test, un test sur le _ avec un ET car le \W ne l'inclut pas.
Problème n°3 : j'ai jouté, aux 2° et 3° tests, un test sur les caractères accentués avec [à-ž]. On peut enlever celui du 3° si l'on considère que seules les lettres minuscules peuvent être accentuées.

Christophe Duguine